### PR TITLE
[AE-519] Added xml empty tags cleanup

### DIFF
--- a/src/DTO/DTO.php
+++ b/src/DTO/DTO.php
@@ -10,7 +10,8 @@ class DTO
     public function __construct(
         private string $class,
         private ?array $validationGroups = null,
-        private ?string $deserializationFormat = null
+        private ?string $deserializationFormat = null,
+        private ?array $context = null
     ) {
     }
 
@@ -44,6 +45,18 @@ class DTO
     public function setDeserializationFormat(?string $deserializationFormat): self
     {
         $this->deserializationFormat = $deserializationFormat;
+
+        return $this;
+    }
+
+    public function getContext(): ?array
+    {
+        return $this->context;
+    }
+
+    public function setContext(?array $context): self
+    {
+        $this->context = $context;
 
         return $this;
     }


### PR DESCRIPTION
- Se añade posibilidad de definir contexto de serialización desde el atributo DTO (para inyectarlo en los controladores)
- Se añade limpieza de tags vacíos de los XMLs (ejemplo: `</amount>`) para que luego en el serializador no se trate como un string vacío ("")