### PR TITLE
add-new-strategy

### DIFF
--- a/src/Adapter/AdapterMapEntity.php
+++ b/src/Adapter/AdapterMapEntity.php
@@ -8,12 +8,14 @@ class AdapterMapEntity
     public const STRICT_STRATEGY = 'strict';
     public const PERSIST_STRATEGY = 'persist';
     public const EARLY_PERSIST_STRATEGY = 'early_persist';
+    public const FIND_OR_PERSIST_STRATEGY = 'find_or_persist';
     public const DEFAULT_STRATEGY = self::STRICT_STRATEGY;
 
     public function __construct(
         private string $class,
         private string $identificatorField = 'uuid',
-        private string $strategy = self::DEFAULT_STRATEGY
+        private string $strategy = self::DEFAULT_STRATEGY,
+        private ?string $fallbackField = null
     ) {
     }
 }

--- a/src/Adapter/GenericAdapter.php
+++ b/src/Adapter/GenericAdapter.php
@@ -69,6 +69,7 @@ class GenericAdapter
         /** @var class-string $class */
         $class = (string) $adapterMapClassAttribute->getArguments()['class'];
         $identificatorField = (string) $adapterMapClassAttribute->getArguments()['identificatorField'];
+        $fallbackField = $adapterMapClassAttribute->getArguments()['fallbackField'] ?? null;
         $strategy = isset($adapterMapClassAttribute->getArguments()['strategy'])
             ?  (string) $adapterMapClassAttribute->getArguments()['strategy']
             : AdapterMapEntity::DEFAULT_STRATEGY;
@@ -93,6 +94,28 @@ class GenericAdapter
                 $this->map($mapObject, $entity);
                 $this->entityManager->persist($entity);
                 $this->entityManager->flush();
+            }
+            if ($strategy === AdapterMapEntity::FIND_OR_PERSIST_STRATEGY) {
+                if (
+                    $fallbackField !== null &&
+                    $this->propertyAccessor->isReadable($mapObject, $fallbackField)
+                ) {
+                    $fallbackValue = $this->propertyAccessor->getValue(
+                        $mapObject,
+                        $fallbackField
+                    );
+                    if ($fallbackValue !== null) {
+                        $entity = $this->entityManager
+                            ->getRepository($class)
+                            ->findOneBy([
+                                $fallbackField => $fallbackValue
+                            ]);
+                    }
+                }
+                if ($entity === null) {
+                    $entity = new $class();
+                }
+                $this->map($mapObject, $entity);
             }
         }
         return $entity;


### PR DESCRIPTION
#### add new Strategy 
- public const FIND_OR_PERSIST_STRATEGY = 'find_or_persist';

#### add new property in construct of attribute
- private ?string $fallbackField = null
```php
public function __construct(
        private string $class,
        private string $identificatorField = 'uuid',
        private string $strategy = self::DEFAULT_STRATEGY,
        private ?string $fallbackField = null
    ) {
    }
```
This property will help us tell it which other field besides the UUID to search in the repository
```php
#[AdapterMapEntity(
    class: Client::class,
    strategy: AdapterMapEntity::FIND_OR_PERSIST_STRATEGY,
    fallbackField: 'email'
)]
```